### PR TITLE
Serialization

### DIFF
--- a/source/PlayerAPI/Card.cpp
+++ b/source/PlayerAPI/Card.cpp
@@ -53,10 +53,10 @@ Value Card::getValue() const
 }
 
 template <class Archive>
-void Card::serialize(Archive &ar, const unsigned int version)
+void Card::serialize(Archive& ar, const unsigned int version)
 {
-  ar & suit;
-  ar & value;
+  ar& suit;
+  ar& value;
 }
 
 // Allows for the '<' comparison of two Card objects.

--- a/source/PlayerAPI/Card.cpp
+++ b/source/PlayerAPI/Card.cpp
@@ -14,6 +14,10 @@
 #include <iterator>
 #include <random>
 
+Card::Card() : suit(), value()
+{
+}
+
 // Constructor for a UNDEFINED card. Needed for if the client chooses to draw
 // from the deck in Crazy Eight's.
 Card::Card(Suit su) : suit(su), value(TWO)
@@ -46,6 +50,13 @@ Suit Card::getSuit() const
 Value Card::getValue() const
 {
   return value;
+}
+
+template <class Archive>
+void Card::serialize(Archive &ar, const unsigned int version)
+{
+  ar & suit;
+  ar & value;
 }
 
 // Allows for the '<' comparison of two Card objects.

--- a/source/PlayerAPI/Card.hpp
+++ b/source/PlayerAPI/Card.hpp
@@ -24,7 +24,11 @@
 #ifndef CARD_HPP
 #define CARD_HPP
 
+// Standard Includes
 #include <vector>
+
+// Boost Includes
+#include <boost/serialization/access.hpp>
 
 enum Suit
 {
@@ -57,12 +61,16 @@ class Card
 private:
   Suit suit;
   Value value;
+  friend class boost::serialization::access;
 
 public:
+  Card();
   Card(Suit su);
   Card(Suit su, Value val);
   Suit getSuit() const;
   Value getValue() const;
+  template <class Archive>
+  void serialize(Archive &ar, const unsigned int);
 };
 
 bool operator<(const Card&, const Card&);

--- a/source/PlayerAPI/Card.hpp
+++ b/source/PlayerAPI/Card.hpp
@@ -70,7 +70,7 @@ public:
   Suit getSuit() const;
   Value getValue() const;
   template <class Archive>
-  void serialize(Archive &ar, const unsigned int);
+  void serialize(Archive& ar, const unsigned int);
 };
 
 bool operator<(const Card&, const Card&);

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -30,7 +30,6 @@ BOOST_AUTO_TEST_CASE(SerializeCard)
 
   BOOST_CHECK_EQUAL(deserializeCard.getSuit(), CLUBS);
   BOOST_CHECK_EQUAL(deserializeCard.getValue(), ACE);
-
 }
 
-//EOF
+// EOF

--- a/test/Test.cpp
+++ b/test/Test.cpp
@@ -4,19 +4,33 @@
 
 #define BOOST_TEST_MODULE const string test;
 
+// Project Includes
+#include "source/PlayerAPI/Card.hpp"
+
+// Standard Includes
+#include <sstream>
+
 // Boost Includes
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/serialization/access.hpp>
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_CASE(cardInitialization)
+BOOST_AUTO_TEST_CASE(SerializeCard)
 {
-  BOOST_CHECK_EQUAL(0, 0);
-  BOOST_CHECK_EQUAL(20, 20);
-}
+  std::stringstream serialize;
+  Card serializeCard(CLUBS, ACE);
+  boost::archive::text_oarchive oArchive(serialize);
+  oArchive << serializeCard;
 
-BOOST_AUTO_TEST_CASE(otherTest)
-{
-  BOOST_CHECK_EQUAL(10, 10);
-  BOOST_CHECK_EQUAL(5, 5);
+  Card deserializeCard;
+  std::stringstream deserialize(serialize.str());
+  boost::archive::text_iarchive iArchive(serialize);
+  iArchive >> deserializeCard;
+
+  BOOST_CHECK_EQUAL(deserializeCard.getSuit(), CLUBS);
+  BOOST_CHECK_EQUAL(deserializeCard.getValue(), ACE);
+
 }
 
 //EOF


### PR DESCRIPTION
This pull request allows us to send information through the networking interface. 

For now, a card can be serialized into a string and then sent over a tcp connection.
A card can also be deserialized when this same string is sent over a connection.

All of the logic teams must add the serialization and deserialization when they are ready to send a card off