### PR TITLE
Fixing Linking errors in CMakeLists for lobby

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -8,4 +8,8 @@ main.cpp
 Lobby.cpp
 Lobby.hpp
 )
-target_link_libraries(Server NetworkInterface Game GameLogic)
+target_link_libraries(Server
+NetworkInterface
+Game
+GameLogic
+${externLibs})


### PR DESCRIPTION
This pull request links boost into the game lobby which fixes build errors on Linux