### PR TITLE
Documentation and LobbyGame message

### DIFF
--- a/Documentation/SDD/SDD.tex
+++ b/Documentation/SDD/SDD.tex
@@ -4,6 +4,7 @@
 \usepackage[margin=1in]{geometry}
 \usepackage{graphicx}
 \usepackage{array}
+\usepackage{longtable}
 \graphicspath{{./graphics/}}
 
 \usepackage{hyperref}

--- a/Documentation/SDD/sections/ServerModel.tex
+++ b/Documentation/SDD/sections/ServerModel.tex
@@ -14,11 +14,11 @@ Register res & Server $\rightarrow$ Client & "SUCCESS" $|$ "$<$ERROR$>$" & ERROR
 \hline
 Login & Client $\rightarrow$ Server & "LOGIN $<$USERNAME$>$ $<$PASSWORD$>$" & USERNAME: custom string PASSWORD: custom string\\
 \hline
-Login res & Server $\rightarrow$ Client & "SUCCESS" $|$ "<ERROR>" & ERROR: (PASSWORD INCORRECT $|$ USER NOT FOUND)\\
+Login res & Server $\rightarrow$ Client & "SUCCESS" $|$ "$<$ERROR$>$" & ERROR: (PASSWORD INCORRECT $|$ USER NOT FOUND)\\
 \hline
 Request games & Client $\rightarrow$ Server & "GET GAMES $<$TYPE$>$" & TYPE: (HEARTS $|$ SPADES $|$ EIGHTS $|$ default: ALL)\\
 \hline
-Games list & Server $\rightarrow$ Client & archive & LobbyGame instances\\
+Games list & Server $\rightarrow$ Client & archive & vector $<$LobbyGame$>$\\
 \hline
 Create game & Client $\rightarrow$ Server & "MAKE $<$TYPE$>$ $<$NAME$>$" & TYPE: (HEARTS $|$ SPADES $|$ EIGHTS) NAME: custom string\\
 \hline

--- a/Documentation/SDD/sections/ServerModel.tex
+++ b/Documentation/SDD/sections/ServerModel.tex
@@ -2,22 +2,31 @@
 \subsection{Class Diagram}
 Coming soon
 \subsection{Message Passing}
+This table isn't very well done, but it should get the point across.
 \begin{center}
-\begin{tabular}{|m{8em}|m{7em}|m{12em}|m{6em}|}
+\begin{longtable}{|m{8em}|m{7em}|m{12em}|m{6em}|}
 \hline
 Function & Direction & Message & Options/ Contents \\
 \hline\hline
-Request games & Client $\rightarrow$ Server & "GET GAMES $<$TYPE$>$" & TYPE: (HEARTS, SPADES, EIGHTS, default: ALL)\\
+Register & Client $\rightarrow$ Server & "REGISTER $<$USERNAME$>$ $<$PASSWORD$>$" & USERNAME: custom string PASSWORD: custom string\\
+\hline
+Register res & Server $\rightarrow$ Client & "SUCCESS" $|$ "$<$ERROR$>$" & ERROR: USERNAME TAKEN\\
+\hline
+Login & Client $\rightarrow$ Server & "LOGIN $<$USERNAME$>$ $<$PASSWORD$>$" & USERNAME: custom string PASSWORD: custom string\\
+\hline
+Login res & Server $\rightarrow$ Client & "SUCCESS" $|$ "<ERROR>" & ERROR: (PASSWORD INCORRECT $|$ USER NOT FOUND)\\
+\hline
+Request games & Client $\rightarrow$ Server & "GET GAMES $<$TYPE$>$" & TYPE: (HEARTS $|$ SPADES $|$ EIGHTS $|$ default: ALL)\\
 \hline
 Games list & Server $\rightarrow$ Client & archive & LobbyGame instances\\
 \hline
-Create game & Client $\rightarrow$ Server & "MAKE $<$TYPE$>$ $<$NAME$>$" & TYPE: (HEARTS, SPADES, EIGHTS) NAME: custom string\\
+Create game & Client $\rightarrow$ Server & "MAKE $<$TYPE$>$ $<$NAME$>$" & TYPE: (HEARTS $|$ SPADES $|$ EIGHTS) NAME: custom string\\
 \hline
-Game created & Server $\rightarrow$ Client & "SUCCESS", "FAILURE: $<$REASON$>$" & REASON: (UNKNOWN GAME TYPE, ALREADY EXISTS)\\
+Game created & Server $\rightarrow$ Client & "SUCCESS" $|$ "FAILURE: $<$REASON$>$" & REASON: (UNKNOWN GAME TYPE $|$ ALREADY EXISTS)\\
 \hline
 Join game & Client $\rightarrow$ Server & "JOIN $<$NAME$>$" & NAME: string from list\\
 \hline
-Game joined & Server $\rightarrow$ Client & "SUCCESS", "FAILURE: $<$REASON$>$" & REASON: (GAME NOT FOUND, GAME FULL)\\
+Game joined & Server $\rightarrow$ Client & "SUCCESS" $|$ "FAILURE: $<$REASON$>$" & REASON: (GAME NOT FOUND $|$ GAME FULL)\\
 \hline
-\end{tabular}
+\end{longtable}
 \end{center}

--- a/source/Lobby.cpp
+++ b/source/Lobby.cpp
@@ -132,7 +132,19 @@ void Lobby::procGetGames(std::shared_ptr<Player> p, std::string msg)
   GameType t = getGameType(msg);
   std::stringstream ss;
   boost::archive::text_oarchive oa(ss);
-  if (t == GameType::ALL)
+  std::vector<LobbyGame> games;
+  if (t == GameType::ALL) {
+	  for (auto game : currentAvailableGames) {
+		  games.push_back(game.second);
+	  }
+  }
+  else {
+	  for (auto game : currentAvailableGames) {
+		  if (game.second.type == t) games.push_back(game.second);
+	  }
+  }
+  oa & games;
+  /*if (t == GameType::ALL)
   {
     for (auto game : currentAvailableGames)
     {
@@ -145,7 +157,7 @@ void Lobby::procGetGames(std::shared_ptr<Player> p, std::string msg)
     {
       if (game.second.type == t) oa << game.second;
     }
-  }
+  }*/
   p->connection->write(ss.str());
 }
 

--- a/source/Lobby.hpp
+++ b/source/Lobby.hpp
@@ -13,6 +13,7 @@
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/serialization/access.hpp>
+#include <boost/serialization/vector.hpp>
 /// Application Includes
 #include "source/GameLogic/CrazyEightsLogic.hpp"
 #include "source/GameLogic/HeartsGame.hpp"

--- a/source/Messages/LobbyGame.hpp
+++ b/source/Messages/LobbyGame.hpp
@@ -6,8 +6,7 @@
 #include <memory>
 
 #include <boost/serialization/access.hpp>
-
-#include "source/PlayerAPI/Player.hpp"
+#include <boost/serialization/string.hpp>
 
 enum GameType
 {

--- a/source/NetworkInterface/TCPConnection.cpp
+++ b/source/NetworkInterface/TCPConnection.cpp
@@ -76,8 +76,8 @@ void TCPConnection::aSyncRead(std::function<void(std::string)> callback)
 
 void TCPConnection::write(std::string msg)
 {
-  if (connected)
-  {
+  /*if (connected)
+  {*/
     try
     {
       boost::asio::write(socket, boost::asio::buffer(msg + "\n"));
@@ -86,11 +86,11 @@ void TCPConnection::write(std::string msg)
     {
       std::cerr << "Exception: " << e.what() << std::endl;
     }
-  }
+  /*}
   else
   {
     std::cout << "Not connected. Message was: " << msg << "\n";
-  }
+  }*/
 }
 
 const char* TCPConnection::getPort()


### PR DESCRIPTION
I think I've finished all the messages for lobby/pregame in the documentation. It doesn't format very well, but the information is there. I also made it so GET GAMES will serialize and send a vector of lobbygames.
There was a fix I did in ServerNetworkConnection that fixed a write exception in some test cases, but it caused non-responsiveness when working with an actual connected client. Probably something to do with bool connected either not getting set to true or getting reset to false when the connection is still live. I commented out the fix to make it work, but that does mean regression in unit tests. @droidkfx can you look at it for me?